### PR TITLE
update docs

### DIFF
--- a/docs/cloudnative-pg.md
+++ b/docs/cloudnative-pg.md
@@ -6,7 +6,7 @@ I'm going to deploy the Cloudnative-pg operator and for now one PostgreSQL clust
 Let's first define the Flux resources I need. The first thing is a helm repository:
 
 ```yaml
-# ./cluster/kubernets/flux-resources/helm/cloudnative-pg.yaml
+# ./cluster/kubernets/flux/resources/helm/cloudnative-pg.yaml
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -21,18 +21,18 @@ spec:
 And next the kustomizations.
 
 ```yaml
-# ./cluster/kubernetes/database/cloudnative-pg/ks.yaml
+# ./cluster/kubernetes/apps/database/cloudnative-pg/ks.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cloudnative-pg
+  name: &app cloudnative-pg
   namespace: flux-system
 spec:
   targetNamespace: database
   commonMetadata:
     labels:
-      app.kubernetes.io/name: cloudnative-pg
+      app.kubernetes.io/name: *app
   dependsOn:
     - name: rook-ceph-cluster
   path: ./cluster/kubernetes/database/cloudnative-pg/app
@@ -48,13 +48,13 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cloudnative-pg-clusters
+  name: &app cloudnative-pg-clusters
   namespace: database
 spec:
   targetNamespace: database
   commonMetadata:
     labels:
-      app.kubernetes.io/name: cloudnative-pg-clusters
+      app.kubernetes.io/name: *app
   dependsOn:
     - name: cloudnative-pg
   path: ./cluster/kubernetes/database/cloudnative-pg/clusters
@@ -77,7 +77,7 @@ The first kustomization is the operator. The second defines all clusters (for no
 The operator is defined using a Helm release.
 
 ```yaml
-# ./cluster/kubernetes/database/cloudnative-pg/app/helmrelease.yaml
+# ./cluster/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -116,7 +116,7 @@ The monitoring is turned off for now, as I still haven't deployed Prometheus.
 As I already mentioned, I'll only deploy a single cluster now. But with the operator, it's very simple to define more in the future.
 
 ```yaml
-# ./cluster/kubernetes/database/cloudnative-pg/clusters/gatus-cluster.yaml
+# ./cluster/kubernetes/apps/database/cloudnative-pg/clusters/gatus-cluster.yaml
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster

--- a/docs/external-dns.md
+++ b/docs/external-dns.md
@@ -6,7 +6,7 @@ External DNS is great little service that automates the creation of dns records.
 Let's first define the Flux resources I need. The first thing is a helm repository:
 
 ```yaml
-# ./cluster/kubernets/flux-resources/helm/external-dns.yaml
+# ./cluster/kubernets/flux/resources/helm/external-dns.yaml
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -21,18 +21,18 @@ spec:
 Next the kustomization:
 
 ```yaml
-# ./cluster/kubernetes/network/external-dns/ks.yaml
+# ./cluster/kubernetes/apps/network/external-dns/ks.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: external-dns-internal
+  name: &app external-dns-internal
   namespace: flux-system
 spec:
   targetNamespace: network
   commonMetadata:
     labels:
-      app.kubernetes.io/name: external-dns-internal
+      app.kubernetes.io/name: *app
   dependsOn:
     - name: pihole
   path: ./cluster/kubernetes/network/external-dns/internal
@@ -54,12 +54,12 @@ spec:
 Depending on what service you use for Ingress, you'll have to set different environment variables. I'm using Gateway API, so I'll have to set some `additionalPermissions` in the values.
 
 ```yaml
-# ./cluster/kubernetes/network/external-dns/internal/helmrelease.yaml
+# ./cluster/kubernetes/apps/network/external-dns/internal/helmrelease.yaml
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
-  name: external-dns-internal
+  name: &app external-dns-internal
 spec:
   interval: 30m
   chart:
@@ -79,7 +79,7 @@ spec:
       strategy: rollback
       retries: 3
   values:
-    fullnameOverride: external-dns-internal
+    fullnameOverride: *app
     serviceMonitor:
       enabled: true
     rbac:

--- a/docs/fluxcd.md
+++ b/docs/fluxcd.md
@@ -224,7 +224,7 @@ resources:
 ```
 
 ```yaml
-# # ./cluster/kubernetes/kube-system/namespace.yaml
+# # ./cluster/kubernetes/apps/kube-system/namespace.yaml
 ---
 apiVersion: v1
 kind: Namespace
@@ -237,7 +237,7 @@ metadata:
 For each app I'll have a file that points to the folder containing the helm release or normal Kubernetes manifest files.
 
 ```yaml
-# ./cluster/kubernetes/kube-system/cilium/ks.yaml
+# ./cluster/kubernetes/apps/kube-system/cilium/ks.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -263,7 +263,7 @@ spec:
 And within `./kubernetes/kube-system/cilium/app` the last Kustomization file:
 
 ```yaml
-# # ./cluster/kubernetes/kube-system/cilium/app/kustomization.yaml
+# # ./cluster/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -27,7 +27,7 @@ I like having exact TLS/SSL certs (not wildcard), which means I'll have to defin
 The following manifest defines the internal Gateway:
 
 ```yaml
-# ./cluster/kubernetes/network/gateways/internal/gateway.yaml
+# ./cluster/kubernetes/apps/network/gateways/internal/gateway.yaml
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -69,7 +69,7 @@ The `tls` section has to conform to the requirements set out by [cert-manager](.
 The first listener is a `http` "catch all" that will catch any local http traffic and forward it to a `HTTPRoute` that'll redirect it to `https`.
 
 ```yaml
-# ./cluster/kubernetes/network/gateways/internal/http-redirect.yaml
+# ./cluster/kubernetes/apps/network/gateways/internal/http-redirect.yaml
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -95,7 +95,7 @@ From here, all listeners below the http redirect listener, will catch traffic bo
 The `HTTPRoute` for `pihole` is defined as follows:
 
 ```yaml
-# ./cluster/kubernetes/network/pihole/ingress/pihole-http-route.yaml
+# ./cluster/kubernetes/apps/network/pihole/ingress/pihole-http-route.yaml
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -119,7 +119,7 @@ The `backendRefs` define which service to route the traffic to.
 
 I'll also add a path redirect to this http route. This is done by another http route, defined as follows:
 ```yaml
-# ./cluster/kubernetes/network/pihole/ingress/pihole-http-route.yaml
+# ./cluster/kubernetes/apps/network/pihole/ingress/pihole-http-route.yaml
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/docs/pihole.md
+++ b/docs/pihole.md
@@ -12,7 +12,7 @@ I'll first define the Flux resources I need.
 First pihole itself:
 
 ```yaml
-# ./cluster/kuberntes/network/pihole/ks.yaml
+# ./cluster/kuberntes/apps/network/pihole/ks.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -44,7 +44,7 @@ spec:
 And OrbitalSync next:
 
 ```yaml
-# ./cluster/kuberntes/network/orbitalsync/ks.yaml
+# ./cluster/kuberntes/apps/network/orbitalsync/ks.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -78,7 +78,7 @@ spec:
 Here are the yaml manifests for pihole itself:
 
 ```yaml
-# ./cluster/kuberntes/network/pihole/app/statefulset-pihole.yaml
+# ./cluster/kuberntes/apps/network/pihole/app/statefulset-pihole.yaml
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -157,7 +157,7 @@ spec:
 Next the configmap for pihole:
 
 ```yaml
-# ./cluster/kuberntes/network/pihole/app/configmap-pihole.yaml
+# ./cluster/kuberntes/apps/network/pihole/app/configmap-pihole.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -174,7 +174,7 @@ Next I'll need three types services:
 3) Some services for the pihole dashboards.
 
 ```yaml
-# ./cluster/kuberntes/network/pihole/app/dns-service.yaml
+# ./cluster/kuberntes/apps/network/pihole/app/dns-service.yaml
 ---
 apiVersion: v1
 kind: Service
@@ -203,7 +203,7 @@ Here I'm using annotations to request a specefic IP: `"io.cilium/lb-ipam-ips"`.
 Because pihole should respond to both UDP and TCP request on port 53, I've added both ports to the service.
 
 ```yaml
-# ./cluster/kuberntes/network/pihole/app/headless-service.yaml
+# ./cluster/kuberntes/apps/network/pihole/app/headless-service.yaml
 ---
 apiVersion: v1
 kind: Service
@@ -219,7 +219,7 @@ spec:
 ```
 
 ```yaml
-# ./cluster/kuberntes/network/pihole/app/dashboard-service.yaml
+# ./cluster/kuberntes/apps/network/pihole/app/dashboard-service.yaml
 ---
 kind: Service
 apiVersion: v1
@@ -280,7 +280,7 @@ The deployment of OrbitalSync is much easier. I'll only need two yaml manifests.
 First the deployment:
 
 ```yaml
-# ./cluster/kuberntes/network/orbitalsync/app/deployment-orbitalsync.yaml
+# ./cluster/kuberntes/apps/network/orbitalsync/app/deployment-orbitalsync.yaml
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -325,7 +325,7 @@ spec:
 And the configmap:
 
 ```yaml
-# ./cluster/kuberntes/network/orbitalsync/app/configmap-orbitalsync.yaml
+# ./cluster/kuberntes/apps/network/orbitalsync/app/configmap-orbitalsync.yaml
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -9,7 +9,7 @@ As always, I need bunch of Flux resources. I'll install Prometheus and Grafana i
 Before I get to the namespace specific resources, I first have to add the two new helm repositories to my cluster, so flux can find them.
 
 ```yaml
-# ./cluster/kuberntes/flux-resources/helm/prometheus-community.yaml
+# ./cluster/kuberntes/flux/resources/helm/prometheus-community.yaml
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -22,7 +22,7 @@ spec:
 ```
 
 ```yaml
-# ./cluster/kuberntes/flux-resources/helm/grafana.yaml
+# ./cluster/kuberntes/flux/resources/helm/grafana.yaml
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -37,7 +37,7 @@ spec:
 Next all the new stuff to setup a new namespace and the two helm charts.
 
 ```yaml
-# ./cluster/kuberntes/observability/kustomization.yaml
+# ./cluster/kuberntes/apps/observability/kustomization.yaml
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -53,7 +53,7 @@ resources:
 This is completely standard, so I won't put all the manifests here. The namespace is a little special.
 
 ```yaml
-# ./cluster/kuberntes/observability/namespace.yaml
+# ./cluster/kuberntes/apps/observability/namespace.yaml
 ---
 apiVersion: v1
 kind: Namespace
@@ -70,7 +70,7 @@ The first label gives everything running in this namespace extra privileges. The
 As I'm installing two seperate helm charts, I've two seperate kustomizations:
 
 ```yaml
-# ./cluster/kuberntes/observability/kube-prometheus-stack/ks.yaml
+# ./cluster/kuberntes/apps/observability/kube-prometheus-stack/ks.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -96,7 +96,7 @@ spec:
 ```
 
 ```yaml
-# ./cluster/kuberntes/observability/grafana/ks.yaml
+# ./cluster/kuberntes/apps/observability/grafana/ks.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -148,7 +148,7 @@ The last kustomization is the ingress resources for grafana.
 Next up are the helm charts. They're both quite long!
 
 ```yaml
-# ./cluster/kuberntes/observability/kube-prometheus-stack/app/helmrelease.yaml
+# ./cluster/kuberntes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -269,7 +269,7 @@ Lastly, the dashboards. These are pretty self explanatory. A lot of people have 
 I'm using some dashboards that aren't published on the grafana website. These can be loaded by pointing to the url where the dashboard json manifest is storaged.
 
 ```yaml
-# ./cluster/kuberntes/observability/grafana/app/helmrelease.yaml
+# ./cluster/kuberntes/apps/observability/grafana/app/helmrelease.yaml
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -451,7 +451,7 @@ spec:
 Lastly I need to setup ingress to grafana. For this I need to add a listener to the `internal` gateway.
 
 ```yaml
-# ./cluster/kubernetes/network/ingress/internal/gateway.yaml
+# ./cluster/kubernetes/apps/network/ingress/internal/gateway.yaml
 ...
 # catch traffic for the grafana dashboard
     - name: grafana
@@ -473,7 +473,7 @@ Lastly I need to setup ingress to grafana. For this I need to add a listener to 
 And add `httproute` to the `observability` namespace.
 
 ```yaml
-# ./cluster/kuberntes/observability/grafana/ingress/grafana-http-route.yaml
+# ./cluster/kuberntes/apps/observability/grafana/ingress/grafana-http-route.yaml
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -509,7 +509,7 @@ There is also an option to deploy a dashboard for grafana. But I already have on
 And then in each pg `cluster` definition I need to set another flag.
 
 ```yaml
-# ./cluster/kubernetes/database/cloudnative-pg/clusters/gatus-cluster.yaml
+# ./cluster/kubernetes/apps/database/cloudnative-pg/clusters/gatus-cluster.yaml
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
@@ -551,7 +551,7 @@ spec:
 I need to add a bit of yaml to the helm chart values:
 
 ```yaml
-# ./cluster/kubernetes/kube-system/cilium/app/helmrelease.yaml
+# ./cluster/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
 prometheus:
   enabled: true
   serviceMonitor:
@@ -568,7 +568,7 @@ operator:
 In order to get cert-manager to pushlish metrics for Prometheus I need to add a bit of yaml to the helm chart values:
 
 ```yaml
-# ./cluster/kubernetes/cert-manager/cert-manager/app/helmrelease.yaml
+# ./cluster/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
 prometheus:
   enabled: true
   servicemonitor:
@@ -579,7 +579,7 @@ prometheus:
 Both the Rook operator and the Ceph cluster can provide metrics. I'll have to enable that in both helm charts:
 
 ```yaml
-# ./cluster/kubernetes/rook-ceph/rook-ceph/app/helmrelease.yaml
+# ./cluster/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
 csi:
   serviceMonitor:
     enabled: true
@@ -590,7 +590,7 @@ monitoring:
 And for the Ceph cluster:
 
 ```yaml
-# ./cluster/kubernetes/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+# ./cluster/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
 monitoring:
   enabled: true
   createPrometheusRules: true
@@ -601,7 +601,7 @@ monitoring:
 Flux can also be monitored using Prometheus. All I need to do is to deploy a `podMonitor`:
 
 ```yaml
-# ./cluster/kubernetes/flux-system/pod-monitor.yaml
+# ./cluster/kubernetes/apps/flux-system/pod-monitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/docs/rook-ceph.md
+++ b/docs/rook-ceph.md
@@ -13,7 +13,7 @@ The first chart installs the Rook operator and the second sets up the actual Cep
 First I'll create the Flux resources needed for the install.
 
 ```yaml
-# ./cluster/kubernetes/flux-resources/helm/rook-ceph.yaml
+# ./cluster/kubernetes/flux/resources/helm/rook-ceph.yaml
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -26,7 +26,7 @@ spec:
 ```
 
 ```yaml
-# ./cluster/kubernetes/rook-ceph/rook-ceph/ks.yaml
+# ./cluster/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -78,7 +78,7 @@ Notice that the `rook-ceph-cluster` kustomization depends on the `rook-ceph` kus
 First the Rook operator chart:
 
 ```yaml
-# /cluster/kubernetes/rook-ceph/rook-ceph/app/helmrelease.yaml
+# /cluster/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -124,7 +124,7 @@ Once I've Prometheus runnig I'll enable the `serviceMonitor` and `monitoring` va
 And the Ceph cluster chart:
 
 ```yaml
-# /cluster/kubernetes/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+# /cluster/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -322,7 +322,7 @@ I've set the `dashboard.port` to 8080 instead of the default 8443, mostly becaus
 Some of the pods need to run in a privileged state. Therefore I need to tell Kubernetes to bypass the normal admission policies for the `rook-ceph` namespace. This can be done by adding a label to the namespace definition:
 
 ```yaml
-# /cluster/kubernetes/rook-ceph/rook-ceph/namespace.yaml
+# /cluster/kubernetes/apps/rook-ceph/rook-ceph/namespace.yaml
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
Quick docs update of mainly paths to actual manifests. Docs still need a major overhaul after the recent refactor.

- **:memo: update cert-manager docs**
- **:memo: update cilium docs**
- **:memo: update cnpg docs**
- **:memo: update external-dns docs**
- **:memo: update flux-operator docs**
- **:memo: update flux docs**
- **:memo: update ingress docs**
- **:memo: update pihole docs**
- **:memo: update prometheus docs**
- **:memo: update rook-ceph docs**
