### PR TITLE
feat(gatus): deploy gatus-sidecar

### DIFF
--- a/cluster/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/cluster/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -23,6 +23,19 @@ spec:
       gatus:
         replicas: 1
         strategy: RollingUpdate
+        initContainers:
+          gatus-sidecar:
+            image:
+              repository: ghcr.io/home-operations/gatus-sidecar
+              tag: 0.0.3
+            args:
+              - --gateway=external-gateway
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 64Mi
+            restartPolicy: Always
         containers:
           app:
             image:
@@ -36,42 +49,36 @@ spec:
                   httpGet:
                     path: /health
                     port: &port 8080
-                  initialDelaySeconds: 10
+                  initialDelaySeconds: 5
                   periodSeconds: 10
-                  successThreshold: 1
-                  failureThreshold: 5
+                  timeoutSeconds: 1
+                  failureThreshold: 3
               readiness: *probes
             securityContext:
               allowPrivilegeEscalation: true
               readOnlyRootFilesystem: true
-              # capabilities:
-              #   drop:
-              #     - 'ALL'
-              #   add:
-              #     - 'NET_RAW'
+              capabilities: { drop: ['ALL'] }
             resources:
               limits:
                 cpu: 250m
-                memory: 100Mi
+                memory: 256Mi
               requests:
                 cpu: 50m
                 memory: 50Mi
-            ports:
-              - containerPort: *port
-                name: http
-                protocol: TCP
+            env:
+              GATUS_CONFIG_PATH: /config
+              GATUS_DELAY_START_SECONDS: 5
+              GATUS_WEB_PORT: *port
             envFrom:
               - secretRef:
                   name: gatus-secret
         serviceAccount:
-          identifier: gatus
-    # defaultPodOptions:
-    #   securityContext:
-    #     runAsNonRoot: true
-    #     runAsUser: 1000
-    #     runAsGroup: 1000
-    #     fsGroup: 1000
-    #     fsGroupChangePolicy: OnRootMismatch
+          identifier: *name
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
     service:
       app:
         controller: *name
@@ -85,6 +92,26 @@ spec:
           - port: http
     serviceAccount:
       gatus: {}
+    rbac:
+      roles:
+        gatus:
+          type: ClusterRole
+          rules:
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - httproutes
+              verbs:
+                - get
+                - watch
+                - list
+      bindings:
+        gatus:
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: *name
+          subjects:
+            - identifier: *name
     persistence:
       config:
         type: emptyDir
@@ -94,4 +121,3 @@ spec:
         globalMounts:
           - path: /config/config.yaml
             subPath: config.yaml
-            readOnly: true


### PR DESCRIPTION
Deploy gatus-sidecar to automatically pick up httproutes and add them to gatus.

Signed-off-by: Christian Olsen <christian@cjsolsen.com>
